### PR TITLE
Hydrate dash id keys

### DIFF
--- a/src/toucan/hydrate.clj
+++ b/src/toucan/hydrate.clj
@@ -200,7 +200,7 @@
         source-keys #{(kw-append dest-key "_id") (kw-append dest-key "-id")}
         ids         (set (for [result results
                                :when  (not (get result dest-key))
-                               :let   [k (some source-keys result)]
+                               :let   [k (some result source-keys)]
                                :when  k]
                            k))
         objs        (if (seq ids)
@@ -208,7 +208,7 @@
                                  {(:id item) item}))
                       (constantly nil))]
     (for [result results
-          :let [source-id (some source-keys result)]]
+          :let [source-id (some result source-keys)]]
       (if (get result dest-key)
         result
         (assoc result dest-key (objs source-id))))))

--- a/test/toucan/hydrate_test.clj
+++ b/test/toucan/hydrate_test.clj
@@ -16,15 +16,15 @@
 ;; ## TESTS FOR HYDRATION HELPER FNS
 
 ;; ### k->k_id
-(def k->k_id (ns-resolve 'toucan.hydrate 'k->k_id))
+(def kw-append (ns-resolve 'toucan.hydrate 'kw-append))
 
 (expect
   :user_id
-  (k->k_id :user))
+  (kw-append :user "_id"))
 
 (expect
-  :toucan_id
-  (k->k_id :toucan))
+  :toucan-id
+  (kw-append :toucan "-id"))
 
 ;; ### can-automagically-batched-hydrate?
 (def can-automagically-batched-hydrate? (ns-resolve 'toucan.hydrate 'can-automagically-batched-hydrate?))
@@ -35,9 +35,14 @@
   (can-automagically-batched-hydrate? [{:a_id 1} {:a_id 2}] :a))
 
 ;; should work for known keys if k_id present in every map
-;; TODO
-#_(expect
-    (can-automagically-batched-hydrate? [{:user_id 1} {:user_id 2}] :user))
+(expect
+ (with-redefs [toucan.hydrate/automagic-batched-hydration-keys (ref #{:user})]
+   (can-automagically-batched-hydrate? [{:user_id 1} {:user_id 2}] :user)))
+
+;; should work for both k_id and k-id style keys
+(expect
+ (with-redefs [toucan.hydrate/automagic-batched-hydration-keys (ref #{:user})]
+   (can-automagically-batched-hydrate? [{:user_id 1} {:user-id 2}] :user)))
 
 ;; should fail for known keys if k_id isn't present in every map
 (expect

--- a/test/toucan/hydrate_test.clj
+++ b/test/toucan/hydrate_test.clj
@@ -1,7 +1,9 @@
 (ns toucan.hydrate-test
   (:require [expectations :refer :all]
             [toucan.hydrate :refer [hydrate]]
-            toucan.test-setup))
+            [toucan.test-models.venue :refer [Venue]]
+            toucan.test-setup
+            [toucan.db :as db]))
 
 (defn- ^:hydrate x [{:keys [id]}]
   id)
@@ -48,6 +50,19 @@
 (expect
   false
   (can-automagically-batched-hydrate? [{:user_id 1} {:user_id 2} {:x 3}] :user))
+
+;; ### automagically-batched-hydrate
+(def automagically-batched-hydrate (ns-resolve 'toucan.hydrate 'automagically-batched-hydrate))
+
+;; it should correctly hydrate
+(expect
+ '({:venue_id 1
+    :venue    #toucan.test_models.venue.VenueInstance{:category :bar, :name "Tempest", :id 1}}
+   {:venue-id 2
+    :venue    #toucan.test_models.venue.VenueInstance{:category :bar, :name "Ho's Tavern", :id 2}})
+ (with-redefs [toucan.hydrate/automagic-batched-hydration-keys (ref #{:venue})
+               toucan.hydrate/automagic-batched-hydration-key->model (ref {:venue Venue})]
+   (automagically-batched-hydrate [{:venue_id 1} {:venue-id 2}] :venue)))
 
 ;; ### valid-hydration-form?
 (def valid-hydration-form? (ns-resolve 'toucan.hydrate 'valid-hydration-form?))

--- a/test/toucan/models_test.clj
+++ b/test/toucan/models_test.clj
@@ -5,7 +5,7 @@
             [toucan.test-setup :as test]
             (toucan.test-models [category :refer [Category], :as category]
                                 [user :refer [User]]
-                                [venue :refer [Venue]])
+                                [venue :refer [Venue map->VenueInstance]])
             [toucan.util.test :as tu]))
 
 ;; Test types (keyword)
@@ -139,7 +139,7 @@
 
 ;; check that we can still override default-fields
 (expect
- #toucan.test_models.venue.VenueInstance{:created-at #inst "2017-01-01T08:00:00.000000000-00:00"}
+ (map->VenueInstance {:created-at test/jan-first-2017})
  (db/select-one [Venue :created-at] :id 1))
 
 ;; Test invoking model as a function (no args)


### PR DESCRIPTION
When hydrating, check for keys ending in either _id or -id.

Also fixes a test that would fail depending on the timezone.

Closes #6.