### PR TITLE
Use HoneySQL to generate INSERT SQL, instead of clojure.java.jdbc

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -1,8 +1,12 @@
 # Toucan Version History & Release Notes
 
-### 1.0.3 (May 3rd, 2017)
+### [Unreleased]
 
-*  Fixed [#6](https://github.com/metabase/toucan/issues/6): Fix hydration for fields that end in `-id`. Credit: [@plexus](https://github.com/plexus)
+* Make `toucan.db/insert!` and friends use HoneySQL, so that you can use `honeysql.core/call` for SQL function calls. ([@plexus](https://github.com/plexus))
+
+### [1.0.3] (May 3rd, 2017)
+
+*  Fixed [#6](https://github.com/metabase/toucan/issues/6): Fix hydration for fields that end in `-id`. ([@plexus](https://github.com/plexus))
 
 ### 1.0.2 (Jan 27th, 2017)
 
@@ -18,3 +22,6 @@
 ### 1.0.0 (Jan 26th, 2017)
 
 *  Initial release of Toucan.
+
+[Unreleased]: https://github.com/metabase/toucan/compare/1.0.3...HEAD
+[1.0.3]: https://github.com/metabase/toucan/compare/1.0.2...1.0.3

--- a/test/toucan/db_test.clj
+++ b/test/toucan/db_test.clj
@@ -3,7 +3,8 @@
             (toucan [db :as db]
                     [models :as models])
             (toucan.test-models [user :refer [User]]
-                                [venue :refer [Venue]])
+                                [venue :refer [Venue]]
+                                [category :refer [Category]])
             [toucan.test-setup :as test]
             [toucan.util.test :as tu]))
 
@@ -169,9 +170,29 @@
 
 ;; TODO - Test simple-delete!
 
-;; TODO - Test simple-insert-many!
+;; Test simple-insert-many!
+(expect
+ '(4 5)
+ (test/with-clean-db
+   (db/simple-insert-many! User [{:first-name "Grass" :last-name #sql/call [:upper "Hopper"]}
+                                 {:first-name "Ko" :last-name "Libri"}])))
 
-;; TODO - Test insert-many!
+(expect
+ '(5)
+ (test/with-clean-db
+   (db/simple-insert-many! Category [{:name "seafood" :parent-category-id 100}])))
+
+;; Test insert-many!
+(expect
+ '(4 5)
+ (test/with-clean-db
+   (db/insert-many! User [{:first-name "Grass" :last-name #sql/call [:upper "Hopper"]}
+                          {:first-name "Ko" :last-name "Libri"}])))
+
+(expect
+ AssertionError ;; triggered by pre-insert hook
+ (test/with-clean-db
+   (db/insert-many! Category [{:name "seafood" :parent-category-id 100}])))
 
 ;; TODO - Test simple-insert!
 
@@ -180,6 +201,11 @@
  #toucan.test_models.user.UserInstance{:id 4, :first-name "Trash", :last-name "Bird"}
  (test/with-clean-db
    (db/insert! User {:first-name "Trash", :last-name "Bird"})))
+
+(expect
+ #toucan.test_models.user.UserInstance{:id 4, :first-name "Grass", :last-name "HOPPER"}
+ (test/with-clean-db
+   (db/insert! User {:first-name "Grass" :last-name #sql/call [:upper "Hopper"]})))
 
 ;; Test select-one
 (expect

--- a/test/toucan/db_test.clj
+++ b/test/toucan/db_test.clj
@@ -170,38 +170,47 @@
 
 ;; TODO - Test simple-delete!
 
-;; Test simple-insert-many!
+;;; Test simple-insert-many!
+
+;; It must return the inserted ids
 (expect
- '(4 5)
+ [5]
+ (test/with-clean-db
+   (db/simple-insert-many! Category [{:name "seafood" :parent-category-id 100}])))
+
+;; it must not fail when using SQL function calls.
+(expect
+ [4 5]
  (test/with-clean-db
    (db/simple-insert-many! User [{:first-name "Grass" :last-name #sql/call [:upper "Hopper"]}
                                  {:first-name "Ko" :last-name "Libri"}])))
 
-(expect
- '(5)
- (test/with-clean-db
-   (db/simple-insert-many! Category [{:name "seafood" :parent-category-id 100}])))
+;;; Test insert-many!
 
-;; Test insert-many!
+;; It must return the inserted ids, it must not fail when using SQL function calls.
 (expect
- '(4 5)
+ [4 5]
  (test/with-clean-db
    (db/insert-many! User [{:first-name "Grass" :last-name #sql/call [:upper "Hopper"]}
                           {:first-name "Ko" :last-name "Libri"}])))
 
+;; It must call pre-insert hooks
 (expect
- AssertionError ;; triggered by pre-insert hook
+ AssertionError ; triggered by pre-insert hook
  (test/with-clean-db
    (db/insert-many! Category [{:name "seafood" :parent-category-id 100}])))
 
 ;; TODO - Test simple-insert!
 
-;; Test insert!
+;;; Test insert!
+
+;; It must return the inserted model
 (expect
  #toucan.test_models.user.UserInstance{:id 4, :first-name "Trash", :last-name "Bird"}
  (test/with-clean-db
    (db/insert! User {:first-name "Trash", :last-name "Bird"})))
 
+;; The returned data must match what's been inserted in the table
 (expect
  #toucan.test_models.user.UserInstance{:id 4, :first-name "Grass", :last-name "HOPPER"}
  (test/with-clean-db


### PR DESCRIPTION
Inserts were being done with jdbc/insert-multi!, which internally generates the
necessary SQL statements. This means HoneySQL is bypassed for inserts, and so
HoneySQL features like calling SQL functions with (sql/call ,,,) are unavailable.

This patch instead makes HoneySQL generate the INSERT statements, and executes
them with the lower level jdbc/db-do-prepared-return-keys. When inserting
multiple rows at once it executes separate INSERT statements, rather than a
single statement with multiple VALUES. This behavior is the same with
jdbc/insert-multi!. It's otherwise not possible to retrieve the primary keys of
the inserted rows. (This is a limitation of jdbc/db-do-prepared-return-keys, not
of JDBC itself).

I've added test-cases for db/insert-many! and db/simple-insert-many!, since
those were still missing, as well as an extra test case for db/insert! which
demonstrates the use of an SQL function call.