### PR TITLE
Make defmodel take protocol implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,10 @@ With Toucan, you just need to define the model, and tell that you want `:status`
 
 ```clojure
 ;; define the User model
-(defmodel User :user)
-
-;; tell Toucan to automatically do Keyword <-> String conversion for :status
-(extend (class User)
-   IModel (merge IModelDefaults
-                 {:types (constantly {:status :keyword})}))
+(defmodel User :user
+  IModel
+  (types [this] ;; tell Toucan to automatically do Keyword <-> String conversion for :status
+    {:status :keyword}))
 ```
 
 After that, whenever you fetch, insert, or update a User, `:status` will automatically be converted appropriately:

--- a/docs/db-functions.md
+++ b/docs/db-functions.md
@@ -429,8 +429,8 @@ say admins have permissions to modify any User, and non-admins only have permiss
 (defprotocol IPermissions
   (can-write? [this]))
 
-(extend-protocol IPermissions
-  (class User)
+(defmodel User :user_table
+  IPermissions
   (can-write? [user]
     (or (current-user-is-admin?)
         (is-current-user? user))))
@@ -445,9 +445,10 @@ This could be taken a step further, and you could implement automatic permission
                     "You don't have permissions to do that.")
             obj))
 
-(extend (class User)
-  models/IModel (merge models/IModelDefaults
-                       {:properties (constantly {:write-check? true})}))
+(defmodel User :user_table
+  models/IModel
+  (properties [_]
+    {:write-check? true}))
 ```
 
 Now whenever you try to `update!` an object with the `:write-check?` property (such as User), `can-write?` must return a truthy

--- a/docs/defining-models.md
+++ b/docs/defining-models.md
@@ -156,9 +156,10 @@ fetching instances of a model. Without `default-fields`, fetching a User might l
 Not ideal! Let's define some `:default-fields` for User:
 
 ```clojure
-(extend (class User)
-  IModel (merge IModelDefaults
-                {:default-fields (constantly [:id :first-name :last-name])}))
+(defmodel User :user_table
+  IModel
+  (default_fields [_]
+    [:id :first-name :last-name]))
 ```
 
 Now, when we fetch a User, we'll only see the `default-fields`:
@@ -193,12 +194,10 @@ be converted to a Keyword when it comes out of the DB, and back into a string wh
 know to take care of this by defining the model as follows:
 
 ```clojure
-(defmodel Venue :my_venue_table)
-
-(extend (class Venue)
-  models/IModel
-  (merge models/IModelDefaults
-         {:types (constantly {:category :keyword})}))
+(defmodel Venue :my_venue_table
+  IModel
+  (types [_]
+    {:category :keyword}))
 ```
 
 Whenever you fetch a Venue, Toucan will automatically apply the appropriate `:out` function for values of `:category`:
@@ -252,12 +251,10 @@ defining a new *property* that can be shared by multiple models:
   :update (fn [obj _]
             (assoc obj :updated-at (java.sql.Timestamp. (System/currentTimeMillis)))))
 
-(defmodel Venue :my_venue_table)
-
-(extend (class Venue)
-  models/IModel
-  (merge models/IModelDefaults
-         {:properties (constantly {:timestamped? true})}))
+(defmodel Venue :my_venue_table
+  IModel
+  (properties [_]
+    {:timestamped? true}))
 ```
 
 In this example, before a Venue is inserted, a new value for `:created-at` and `:updated-at` will be added; before
@@ -292,13 +289,12 @@ any desired changes.
 This provides an opportunity to do things like encode JSON or provide default values for certain fields.
 
 ```clojure
-(defn- pre-insert [user]
-  (let [defaults {:version 1}]
-    (merge defaults user))) ; set some default values"
+(defmodel User :user_table
+  IModel
+  (pre-insert [user]
+    (let [defaults {:version 1}]
+      (merge defaults user)))) ; set some default values"
 
-(extend (class User)
-  IModel (merge IModelDefaults
-                {:pre-insert pre-insert}))
 ```
 
 `pre-insert` is a good opportunity to set default values for things, as shown above, or do constraint checking that would otherwise
@@ -395,9 +391,10 @@ to find the User ID, and fetch the `Users` corresponding to those values.
 
 ```clojure
 ;; tell hydrate to fetch Users when hydrating :creator
-(extend (class User)
-  IModel (merge IModelDefaults
-           {:hydration-keys (constantly [:creator])}))
+(defmodel User :user_table
+  IModel
+  (hydration-keys [_]
+    [:creator]))
 ```
 
 e.g.

--- a/docs/hydration.md
+++ b/docs/hydration.md
@@ -66,13 +66,11 @@ If the key being hydrated is defined as one of some model's `hydration-keys`,
 is found in the objects being batch hydrated.
 
 ```clojure
-(models/defmodel User :users)
-
-;; tell Toucan to do batched hydration of the key `:user` by fetching instances of User with given `:id`s
-(extend (class User)
-   models/IModel
-   (merge models/IModelDefaults
-          {:hydration-keys (constantly [:user])}))
+(models/defmodel User :users
+  models/IModel
+  ;; tell Toucan to do batched hydration of the key `:user` by fetching instances of User with given `:id`s
+  (hydration-keys []
+    [:user]))
 
 ;; ... later, somewhere else ...
 

--- a/test/toucan/models_test.clj
+++ b/test/toucan/models_test.clj
@@ -159,6 +159,11 @@
  #toucan.test_models.venue.VenueInstance{:category :store, :name "BevMo", :id 3}
  (Venue :name "BevMo"))
 
+;; Test invoking model as a function with apply
+(expect
+ #toucan.test_models.venue.VenueInstance{:category :store, :name "BevMo", :id 3}
+ (apply Venue [:name "BevMo"]))
+
 ;; Test using model in HoneySQL form
 (expect
  [{:id 1, :name "Tempest"}
@@ -167,3 +172,8 @@
  (db/query {:select   [:id :name]
             :from     [Venue]
             :order-by [:id]}))
+
+;; Test (empty)
+(expect
+ #toucan.test_models.venue.VenueInstance{}
+ (empty (Venue :name "BevMo")))

--- a/test/toucan/test_models/category.clj
+++ b/test/toucan/test_models/category.clj
@@ -40,10 +40,15 @@
   new-category)
 
 
-(extend (class Category)
+(models/defmodel Category :categories
   models/IModel
-  (merge models/IModelDefaults {:types       (constantly {:name :lowercase-string})
-                                :pre-insert  assert-parent-category-exists
-                                :post-insert add-category-to-moderation-queue!
-                                :pre-update  assert-parent-category-exists
-                                :pre-delete  delete-child-categories}))
+  (types [_]
+    {:name :lowercase-string})
+  (pre-insert [this]
+    (assert-parent-category-exists this))
+  (post-insert [this]
+    (add-category-to-moderation-queue! this))
+  (pre-update [this]
+    (assert-parent-category-exists this))
+  (pre-delete [this]
+    (delete-child-categories this)))


### PR DESCRIPTION
Pass implementations of protocols directly to `defmodel`, the same way you would
do in `defrecord` or `deftype`. (fixes #9)

Also provides implementations for `empty` (fixes #1) and `apply` (fixes #2).

This updates the documentation, promoting this way of doing things as the
preferred method (vs using extend...merge...IModelDefaults), but still leaves in
an example of how to do things the old-fashioned way.

The defining-models doc has been expanded slightly to further clarify the
relationship between `User` and `(User 1`).

The fill column in that document was irregular but seemed to hover around 120,
so I went with breaking lines at 120 characters. It might be best to ignore
whitespace changes when reviewing this.

Note that as it stands you can implement protocols in `defmodel`, but not
interfaces, since the forms are inserted in `extend` rather than in `defrecord`
itself. To fix this we'll have to separate extensions to IModel from other
interface/protocol implementations.