### PR TITLE
Add new flush-hydration-keys-caches fn for REPL usage

### DIFF
--- a/VERSION-HISTORY.md
+++ b/VERSION-HISTORY.md
@@ -1,5 +1,10 @@
 # Toucan Version History & Release Notes
 
+### [1.1.6](https://github.com/metabase/toucan/compare/1.1.5...1.1.6) (May 16th, 2018)
+
+*  Add new [`toucan.hydrate/flush-hydration-key-caches!`](https://github.com/metabase/toucan/blob/master/docs/hydration.md#flushing-the-hydration-key-caches-for-interactive-repl-development)
+   function for interactive development. (PRs [#27](https://github.com/metabase/toucan/pull/27) and [#35](https://github.com/metabase/toucan/pull/35), Credit: [@axrs](https://github.com/axrs) with some cleanup by [@camsaul](https://github.com/camsaul))
+
 ### [1.1.5](https://github.com/metabase/toucan/compare/1.1.4...1.1.5) (May 15th, 2018)
 
 *  Add support for newer versions of H2 database.

--- a/docs/hydration.md
+++ b/docs/hydration.md
@@ -165,3 +165,13 @@ will be hydrated *inside* the corresponding values for that key.
   [:a [:b :c] :e])
 ;; -> {:a {:b {:c 1} :e 2}}
 ```
+
+## Flushing the Hydration Key Caches for Interactive (REPL) Development
+
+The functions that can be used to hydrate things are resolved and cached the first time you call `hydrate`. In an
+interactive development environment (such as a REPL), you'll sometimes find yourself wanting to add new hydration
+functions. Luckily, one simple call can flush the caches, allowing you to add new hydration functions as you please:
+
+```clojure
+(toucan.hydrate/flush-hydration-key-caches!)
+```

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject toucan "1.1.6-snapshot"
+(defproject toucan "1.1.6"
   :description "Functionality for defining your application's models and querying the database."
   :url "https://github.com/metabase/toucan"
   :license {:name "Eclipse Public License"

--- a/src/toucan/hydrate.clj
+++ b/src/toucan/hydrate.clj
@@ -282,7 +282,8 @@
 ;;; ==================================================================================================================
 
 (defn flush-hydration-key-caches!
-  "Clear out the cached hydration keys. Useful when doing interactive development and defining new hydration functions."
+  "Clear out the cached hydration keys. Useful when doing interactive development and defining new hydration
+  functions."
   []
   (reset! automagic-batched-hydration-key->model* nil)
   (reset! hydration-key->batched-f*               nil)


### PR DESCRIPTION
Inspired by PR #27. Fixes #24.

Adds a new function called `toucan.hydrate/flush-hydration-key-caches!` which will prove useful in REPL development