### PR TITLE
Remove classpath scanning in automagic batched hydration

### DIFF
--- a/src/toucan/hydrate.clj
+++ b/src/toucan/hydrate.clj
@@ -167,9 +167,6 @@
 
   This is built pulling the `hydration-keys` set from all of our entities."
   []
-  (doseq [ns-symb (ns-find/find-namespaces (classpath/classpath))
-          :when   (s/starts-with? (name ns-symb) (str (models/root-namespace) \.))]
-    (require ns-symb))
   (into {} (for [ns       (all-ns)
                  [_ varr] (ns-publics ns)
                  :let     [model (var-get varr)]


### PR DESCRIPTION
This code is pretty slow with large classpaths, taking over 10 seconds
in Metabase. This code is also broken on JDK 9 due to the classloader
changes, `classpath/classpath` will always return the empty
list. With this removed, all of the Metabase tests still pass and we
can save that 10 second load time the first time hydration is called.

