### PR TITLE
Don't use clojars deploy context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,6 @@ workflows:
           requires:
             - checkout
       - deploy:
-          context: clojars
           requires:
             - test
             - lint-bikeshed


### PR DESCRIPTION
I put the secret env vars in the toucan project config instead of sharing them across all Metabase projects. Less risky