### PR TITLE
Change model? to check for records

### DIFF
--- a/src/toucan/models.clj
+++ b/src/toucan/models.clj
@@ -378,9 +378,11 @@
   ([model k v & more]
    (apply (resolve 'toucan.db/select-one) model k v more)))
 
-(def ^:const ^{:arglists '([model])} ^Boolean model?
+(defn model?
   "Is model a valid toucan model?"
-  ::model)
+  [model]
+  (and (record? model)
+       (::model model)))
 
 ;; We use the same record type (e.g., `DatabaseInstance`) for both the "model" (e.g., `Database`) and objects fetched
 ;; from the DB ("instances"). Model definitions have the key `::model` assoced so we can differentiate.


### PR DESCRIPTION
Calling values with a keyword is not always safe or free of side effects, since
model? is called on every loaded var we need to be more conservative.

Closes #55 

@camsaul 