### PR TITLE
Use locale agnostic `clojure.string/lower-case`

### DIFF
--- a/src/toucan/db.clj
+++ b/src/toucan/db.clj
@@ -153,7 +153,7 @@
      (model-symb->ns 'CardFavorite) -> 'my-project.models.card-favorite"
   [symb]
   {:pre [(symbol? symb)]}
-  (symbol (str (models/root-namespace) \. (s/lower-case (s/replace (name symb) #"([a-z])([A-Z])" "$1-$2")))))
+  (symbol (str (models/root-namespace) \. (u/lower-case (s/replace (name symb) #"([a-z])([A-Z])" "$1-$2")))))
 
 (defn- resolve-model-from-symbol
   "Resolve the model associated with SYMB, calling `require` on its namespace if needed.
@@ -271,7 +271,11 @@
   "Compile `honeysql-from` and call `jdbc/query` against the application database. Options are passed along to
   `jdbc/query`."
   [honeysql-form & {:as options}]
-  (jdbc/query (connection) (honeysql->sql honeysql-form) options))
+  (jdbc/query (connection)
+              (honeysql->sql honeysql-form)
+              ; FIXME: This has already been fixed in `clojure.java.jdbc`, so
+              ;        this option can be removed when using >= 0.7.10.
+              (into options {:identifiers u/lower-case})))
 
 (defn reducible-query
   "Compile `honeysql-from` and call `jdbc/reducible-query` against the application database. Options are passed along

--- a/src/toucan/db.clj
+++ b/src/toucan/db.clj
@@ -273,8 +273,8 @@
   [honeysql-form & {:as options}]
   (jdbc/query (connection)
               (honeysql->sql honeysql-form)
-              ; FIXME: This has already been fixed in `clojure.java.jdbc`, so
-              ;        this option can be removed when using >= 0.7.10.
+              ;; FIXME: This has already been fixed in `clojure.java.jdbc`, so
+              ;;        this option can be removed when using >= 0.7.10.
               (into options {:identifiers u/lower-case})))
 
 (defn reducible-query

--- a/src/toucan/util.clj
+++ b/src/toucan/util.clj
@@ -16,5 +16,5 @@
   `clojure.string/lower-case` uses the default locale in conversions, turning
   `ID` into `ıd`, in the Turkish locale. This function always uses the
   `Locale/US` locale."
-  [s]
+  [^CharSequence s]
   (.. s toString (toLowerCase (Locale/US))))

--- a/src/toucan/util.clj
+++ b/src/toucan/util.clj
@@ -1,6 +1,7 @@
 (ns toucan.util
   "Utility functions used by other Toucan modules."
-  (:require [clojure.string :as s]))
+  (:require [clojure.string :as s])
+  (:import java.util.Locale))
 
 (defn keyword->qualified-name
   "Return keyword K as a string, including its namespace, if any (unlike `name`).
@@ -9,3 +10,11 @@
   [k]
   (when k
     (s/replace (str k) #"^:" "")))
+
+(defn lower-case
+  "Locale-agnostic version of `clojure.string/lower-case`.
+  `clojure.string/lower-case` uses the default locale in conversions, turning
+  `ID` into `ıd`, in the Turkish locale. This function always uses the
+  `Locale/US` locale."
+  [s]
+  (.. s toString (toLowerCase (Locale/US))))


### PR DESCRIPTION
Without this change `clojure.string/lower-case` uses the default locale,
turning (for example) "ID" into ":ıd" in the Turkish locale.

@camsaul