### PR TITLE
Make *transaction-connection* public

### DIFF
--- a/src/toucan/db.clj
+++ b/src/toucan/db.clj
@@ -109,7 +109,7 @@
 ;;;                                         TRANSACTION & CONNECTION UTIL FNS
 ;;; ==================================================================================================================
 
-(def ^:private ^:dynamic *transaction-connection*
+(def ^:dynamic *transaction-connection*
   "Transaction connection to the application DB. Used internally by `transaction`."
   nil)
 


### PR DESCRIPTION
As discussed in #42, let's mark `*transaction-connection*` as public so that the default database connection can be set using dynamic variables instead of using the global mutable state.