### PR TITLE
Use Potemkin to define model record types in defmodel macro

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject toucan "1.14.1"
+(defproject toucan "1.15"
   :description "Functionality for defining your application's models and querying the database."
   :url "https://github.com/metabase/toucan"
   :license {:name "Eclipse Public License"
@@ -22,7 +22,8 @@
    [org.clojure/java.jdbc "0.7.10"]
    [org.clojure/tools.logging "0.5.0"]
    [org.clojure/tools.namespace "0.3.1"]
-   [honeysql "0.9.8"]]
+   [honeysql "0.9.8"]
+   [potemkin "0.4.5"]]
 
   :profiles
   {:dev

--- a/src/toucan/models.clj
+++ b/src/toucan/models.clj
@@ -3,6 +3,7 @@
    the `IModel` protocol and default implementations, which implement Toucan model functionality."
   (:require [clojure.walk :refer [postwalk]]
             [honeysql.format :as hformat]
+            [potemkin.types :as p.types]
             [toucan.util :as u])
   (:import honeysql.format.ToSql))
 
@@ -174,7 +175,7 @@
 ;;;                                                 IModel Interface
 ;;; ==================================================================================================================
 
-(defprotocol IModel
+(p.types/defprotocol+ IModel
   "The `IModel` protocol defines the various methods that are used to provide custom behavior for various models.
 
    This protocol contains the various methods model classes can optionally implement. All methods have a default
@@ -312,7 +313,7 @@
         :else   (recur obj       more)))))
 
 
-(defprotocol ICreateFromMap
+(p.types/defprotocol+ ICreateFromMap
   "Used by internal functions like `do-post-select`."
   (^:private map-> [klass, ^clojure.lang.IPersistentMap m]
    "Convert map M to instance of record type KLASS."))
@@ -489,7 +490,7 @@
                               (drop 1 args))
         instance            (symbol (str model "Instance"))
         map->instance       (symbol (str "map->" instance))
-        defrecord-form      `(defrecord ~instance []
+        defrecord-form      `(p.types/defrecord+ ~instance []
                                clojure.lang.Named
                                (~'getName [~'_] ~(name model))
                                (~'getNamespace [~'_] ~(name (ns-name *ns*)))

--- a/src/toucan/util/test.clj
+++ b/src/toucan/util/test.clj
@@ -1,6 +1,7 @@
 (ns toucan.util.test
   "Utility functions for writing tests with Toucan models."
-  (:require [toucan.db :as db]))
+  (:require [toucan.db :as db]
+            [potemkin.types :as p.types]))
 
 ;;;                                                    TEMP OBJECTS
 ;;; ==================================================================================================================
@@ -68,7 +69,7 @@
 ;; similar macros for other unit test frameworks are welcome!)
 
 
-(defprotocol WithTempDefaults
+(p.types/defprotocol+ WithTempDefaults
   "Protocol defining the `with-temp-defaults` method, which provides default values for new temporary objects."
   (with-temp-defaults ^clojure.lang.IPersistentMap [this]
     "Return a map of default values that should be used when creating a new temporary object of this model.

--- a/src/toucan/util/test.clj
+++ b/src/toucan/util/test.clj
@@ -1,7 +1,7 @@
 (ns toucan.util.test
   "Utility functions for writing tests with Toucan models."
-  (:require [toucan.db :as db]
-            [potemkin.types :as p.types]))
+  (:require [potemkin.types :as p.types]
+            [toucan.db :as db]))
 
 ;;;                                                    TEMP OBJECTS
 ;;; ==================================================================================================================


### PR DESCRIPTION
I originally intended to implement this in #62 but I think I must have forgotten to check in all of the changes to make it happen. This PR implements the actual changes

*  `defmodel` macro generates a record type using [Potemkin](https://github.com/ztellman/potemkin) `defrecord+` instead of vanilla Clojure `defrecord`. This behaves identically to normal `defrecord` for all intents and purposes, but unlike vanilla `defrecord`, reevaluating the form will not replace the original class if the form itself has not changed. This makes working with Toucan models during interactive development an order of magnitude easier: previously, reloading a namespace containing a Toucan model would require you to reload any other namespaces that used that class, e.g. for interface/protocol/multimethod dispatch.

