### PR TITLE
Always default :identifiers to u/lower-case

### DIFF
--- a/src/toucan/db.clj
+++ b/src/toucan/db.clj
@@ -105,15 +105,18 @@
   [db-connection-map]
   (reset! default-db-connection db-connection-map))
 
-(defonce ^:private default-jdbc-options
+(defonce ^:private default-default-jdbc-options
   ;; FIXME: This has already been fixed in `clojure.java.jdbc`, so
   ;;        this option can be removed when using >= 0.7.10.
-  (atom {:identifiers u/lower-case}))
+  {:identifiers u/lower-case})
+
+(defonce ^:private default-jdbc-options
+  (atom default-default-jdbc-options))
 
 (defn set-default-jdbc-options!
   "Set the default options to be used for all calls to `clojure.java.jdbc/query` or `execute!`."
   [jdbc-options]
-  (reset! default-jdbc-options jdbc-options))
+  (reset! default-jdbc-options (merge default-default-jdbc-options jdbc-options)))
 
 
 


### PR DESCRIPTION
If we don't, and options are set via `db/set-default-jdbc-options!`, clojure.jdbc will default back to locale-aware `clojure.string/lower-case`. Unless the user specifies something else, `u/lower-case` is always preferable.

This fixes metabase/metabase#12171.