### PR TITLE
reducible-query/select-reducible should merge default JDBC options

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject toucan "1.15.2-SNAPSHOT"
+(defproject toucan "1.15.3"
   :description "Functionality for defining your application's models and querying the database."
   :url "https://github.com/metabase/toucan"
   :license {:name "Eclipse Public License"

--- a/src/toucan/db.clj
+++ b/src/toucan/db.clj
@@ -293,7 +293,7 @@
   "Compile `honeysql-from` and call `jdbc/reducible-query` against the application database. Options are passed along
   to `jdbc/reducible-query`. Note that the query won't actually be executed until it's reduced."
   [honeysql-form & {:as options}]
-  (jdbc/reducible-query (connection) (honeysql->sql honeysql-form) options))
+  (jdbc/reducible-query (connection) (honeysql->sql honeysql-form) (merge @default-jdbc-options options)))
 
 
 (defn qualify

--- a/test/toucan/db_test.clj
+++ b/test/toucan/db_test.clj
@@ -254,6 +254,16 @@
   #{#toucan.test_models.user.UserInstance{:id 1, :first-name "Cam", :last-name "Saul"}}
   (transduce-to-set (db/simple-select-reducible User {:where [:= :id 1]})))
 
+;; reducible-query should pass default JDBC options along to clojure.java.jdbc
+(expect
+ (:connection [""] {:a 1, :b 3, :c 4})
+ (let [fn-args (atom nil)]
+    (with-redefs [db/connection           (constantly :connection)
+                  db/default-jdbc-options (atom {:a 1, :b 2})
+                  jdbc/reducible-query    (fn [& args]
+                                            (reset! fn-args args))]
+      (db/reducible-query {} :b 3, :c 4))))
+
 ;; Test simple-select-one
 (expect
  #toucan.test_models.user.UserInstance{:id 1, :first-name "Cam", :last-name "Saul"}

--- a/test/toucan/db_test.clj
+++ b/test/toucan/db_test.clj
@@ -256,7 +256,7 @@
 
 ;; reducible-query should pass default JDBC options along to clojure.java.jdbc
 (expect
- (:connection [""] {:a 1, :b 3, :c 4})
+ [:connection [""] {:a 1, :b 3, :c 4}]
  (let [fn-args (atom nil)]
     (with-redefs [db/connection           (constantly :connection)
                   db/default-jdbc-options (atom {:a 1, :b 2})


### PR DESCRIPTION
Fix bug where `reducible-query` wasn't merging in the default JDBC options map