### PR TITLE
Implement type-fns support for PK

### DIFF
--- a/src/toucan/models.clj
+++ b/src/toucan/models.clj
@@ -351,6 +351,13 @@
     (map-> model <>)
     (apply-property-fns :select <>)))
 
+(defn do-type-fn
+  "Don't call this directly! This is automatically applied when doing select."
+  [model col v direction]
+  (if-let [type (col (types model))]
+    ((get-in @type-fns [type direction]) v)
+    v))
+
 (def IModelDefaults
   "Default implementations for `IModel` methods."
   {:default-fields (constantly nil)

--- a/test/toucan/db_test.clj
+++ b/test/toucan/db_test.clj
@@ -10,6 +10,7 @@
             [toucan.test-models
              [address :refer [Address]]
              [category :refer [Category]]
+             [food :refer [Food]]
              [phone-number :refer [PhoneNumber]]
              [user :refer [User]]
              [venue :refer [Venue]]])
@@ -286,6 +287,13 @@
       (db/update! PhoneNumber id :country_code "AU")
       (db/select-one PhoneNumber :number id))))
 
+(expect
+ #toucan.test_models.food.FoodInstance{:id "F4", :price 42.42M}
+ (test/with-clean-db
+  (db/insert! Food {:id "F4" :price 9.01M})
+  (db/update! Food "F4" :price 42.42M)
+  (db/select-one Food :id "F4")))
+
 ;; Test update-where!
 (expect
  [#toucan.test_models.user.UserInstance{:id 1, :first-name "Cam", :last-name "Saul"}
@@ -502,3 +510,11 @@
   (db/exists? User, :first-name "Kanye", :last-name "Nest"))
 
 ;; TODO - Test delete!
+
+;; Test delete! with transformed PK
+(expect
+ 0
+ (test/with-clean-db
+  (db/insert! Food {:id "F4" :price 9.01M})
+  (db/delete! Food :id "F4")
+  (db/count Food :id "F4")))

--- a/test/toucan/test_models/food.clj
+++ b/test/toucan/test_models/food.clj
@@ -1,0 +1,22 @@
+(ns toucan.test-models.food
+  "A model with BYTEA as primary key."
+  (:require [toucan.models :as models])
+  (:import (java.nio.charset StandardCharsets)))
+
+(defn- str->bytes [s]
+  (when s
+    (.getBytes s StandardCharsets/UTF_8)))
+
+(defn- bytes->str [b]
+  (when b
+    (String. b StandardCharsets/UTF_8)))
+
+;; Store string as byte array in the database
+(models/add-type! :string-as-bytes
+                  :in  str->bytes
+                  :out bytes->str)
+
+(models/defmodel Food :foods
+  models/IModel
+  (types [_]
+    {:id :string-as-bytes}))

--- a/test/toucan/test_setup.clj
+++ b/test/toucan/test_setup.clj
@@ -70,7 +70,13 @@
       number TEXT PRIMARY KEY,
       country_code VARCHAR(3) NOT NULL
     );"
-    "TRUNCATE TABLE phone_numbers;"))
+    "TRUNCATE TABLE phone_numbers;"
+    ;; Food
+    "CREATE TABLE IF NOT EXISTS foods (
+      id BYTEA PRIMARY KEY,
+      price DECIMAL(10,2) NOT NULL
+    );"
+    "TRUNCATE TABLE foods;"))
 
 
 (def ^java.sql.Timestamp jan-first-2017 (Timestamp/valueOf "2017-01-01 00:00:00"))


### PR DESCRIPTION
Apply `type-fns` to PK before using it in the database and vice versa.

Note that this might be a breaking change for callers who already convert the input to the database-native type since Toucan previously did not consistently apply type-fns (e.g. applied on insert and update, but not where clause in select)

Fixes #65
