### PR TITLE
Model resolution registry

### DIFF
--- a/src/toucan/models.clj
+++ b/src/toucan/models.clj
@@ -447,6 +447,12 @@
                [(fully-qualified-symbol form) acc]
                [type (assoc-in acc [type (keyword (first form))] `(fn ~@(drop 1 form)))])) [nil {}] forms)))
 
+(defonce
+  ^{:doc "Mapping from model name to namespace containing the model. Useful in order to resolve models which
+  are not defined in a namespace matching the convention."}
+  model-sym->namespace-sym
+  (atom {}))
+
 (defmacro defmodel
   "Define a new \"model\". Models encapsulate information and behaviors related to a specific table in the application
   DB, and have their own unique record type.
@@ -515,6 +521,7 @@
                                      f))
                                  (macroexpand defrecord-form))]
     `(do
+       (swap! @#'model-sym->namespace-sym assoc '~model (ns-name *ns*))
        ~defrecord-form
 
        (extend ~instance

--- a/src/toucan/models.clj
+++ b/src/toucan/models.clj
@@ -447,9 +447,9 @@
                [(fully-qualified-symbol form) acc]
                [type (assoc-in acc [type (keyword (first form))] `(fn ~@(drop 1 form)))])) [nil {}] forms)))
 
-(defonce
-  ^{:doc "Mapping from model name to namespace containing the model. Useful in order to resolve models which
-  are not defined in a namespace matching the convention."}
+(defonce ^{:doc "Mapping from model name to namespaces containing the model. Useful in order to resolve models which
+  are not defined in a namespace matching the convention. Keys are sets of namespaces to help in error reporting if
+  there are multiple namespaces matching a single model name."}
   model-sym->namespace-sym
   (atom {}))
 
@@ -521,7 +521,7 @@
                                      f))
                                  (macroexpand defrecord-form))]
     `(do
-       (swap! @#'model-sym->namespace-sym assoc '~model (ns-name *ns*))
+       (swap! @#'model-sym->namespace-sym update '~model (fnil conj #{}) (ns-name *ns*))
        ~defrecord-form
 
        (extend ~instance

--- a/test/toucan/db_test.clj
+++ b/test/toucan/db_test.clj
@@ -175,7 +175,7 @@
 ;; We save the defining namespace in an atom keyed by model symbol
 (expect
   (get @models/model-sym->namespace-sym 'Nowfound)
-  'toucan.db-test)
+  #{'toucan.db-test})
 
 ;; ... as should trying to resolve things that aren't entities or symbols
 (expect Exception (db/resolve-model {}))

--- a/test/toucan/db_test.clj
+++ b/test/toucan/db_test.clj
@@ -163,7 +163,19 @@
 ;; Trying to resolve an model that cannot be found should throw an Exception
 (expect
  Exception
- (db/resolve-model 'Fish))
+ (db/resolve-model 'Unfound))
+
+(models/defmodel Nowfound :testing_model_resolution)
+
+;; we can resolve models when their namespace doesn't follow convention
+(expect
+  Nowfound
+  (db/resolve-model 'Nowfound))
+
+;; We save the defining namespace in an atom keyed by model symbol
+(expect
+  (get @models/model-sym->namespace-sym 'Nowfound)
+  'toucan.db-test)
 
 ;; ... as should trying to resolve things that aren't entities or symbols
 (expect Exception (db/resolve-model {}))


### PR DESCRIPTION
#### Changes:

add a model registry from model symbol to set of namespaces that defines it. Use this registry to look up when model is used as a symbol, eg `(db/select 'Foo :id 1)`.

##### Suggested breaking change

Before this change, defining multiple models with the same name and querying by model symbol would always resolve to the model defined in the "conventional" namespace as constructed with `model/root-namespace`. If there were multiple models defined in "unconventional" locations, it would never find either of them. The registry is checked after the inferred namespace to preserve this behavior. But it might be better to change this behavior. Rather than allowing multiple model definitions like this, perhaps we could check the inferred location and also the registered locations and ensure we do not have an ambiguous model reference.

There is probably a small chance of this happening but having models findable in non-standard locations might increase the odds of it a little bit.

ie, if you define a normal model `User` in the conventional location (`(defmodel User :production_user_table)`) and a test file defines `(defmodel User :test_user_table)`, usages of `'User` as a symbol would resolve to the production user table. It might be better to throw in this case, even if this is a remote scenario.